### PR TITLE
Add credential issuance, revocation, and verification functions with validation and data retrieval in STACKS-BlockCreds contract.

### DIFF
--- a/contracts/STACKS-BlockCreds.clar
+++ b/contracts/STACKS-BlockCreds.clar
@@ -1,3 +1,4 @@
+
 ;; STACKS-BlockCreds
 
 ;; Error codes
@@ -126,4 +127,105 @@
             credential-validity-period: validity-period-blocks
         }))
     )
+)
+
+(define-public (issue-credential
+    (credential-uuid (string-ascii 50))
+    (student-address principal)
+    (credential-type-identifier (string-ascii 50))
+    (credential-document-hash (buff 32))
+    (additional-credential-info (string-ascii 256))
+)
+    (let (
+        (education-provider-profile (unwrap! (map-get? authorized-educational-institutions tx-sender) ERR-RECORD-NOT-FOUND))
+        (credential-category-details (unwrap! (map-get? supported-credential-categories credential-type-identifier) ERR-UNSUPPORTED-CREDENTIAL-TYPE))
+        (current-block-height stacks-block-height)
+        (expiration-block-height (+ current-block-height (get credential-validity-period credential-category-details)))
+    )
+        (asserts! (is-valid-string credential-uuid) ERR-INVALID-INPUT)
+        (asserts! (is-valid-principal student-address) ERR-ZERO-ADDRESS)
+        (asserts! (is-valid-string credential-type-identifier) ERR-INVALID-INPUT)
+        (asserts! (is-valid-string additional-credential-info) ERR-INVALID-INPUT)
+        (asserts! (is-valid-hash credential-document-hash) ERR-INVALID-HASH)  ;; Added hash validation
+        (asserts! (get education-provider-verification-status education-provider-profile) ERR-NOT-AUTHORIZED)
+        (asserts! (is-none (map-get? credential-records {
+            credential-uuid: credential-uuid, 
+            student-address: student-address
+        })) ERR-DUPLICATE-CREDENTIAL)
+
+        (ok (map-set credential-records 
+            {credential-uuid: credential-uuid, student-address: student-address}
+            {
+                education-provider-address: tx-sender,
+                issuance-block-height: current-block-height,
+                expiration-block-height: expiration-block-height,
+                credential-type-identifier: credential-type-identifier,
+                credential-document-hash: credential-document-hash,
+                additional-credential-info: additional-credential-info,
+                revocation-status: false
+            }
+        ))
+    )
+)
+
+(define-public (revoke-credential 
+    (credential-uuid (string-ascii 50)) 
+    (student-address principal)
+)
+    (let (
+        (credential-record (unwrap! 
+            (map-get? credential-records 
+                {credential-uuid: credential-uuid, student-address: student-address}
+            ) 
+            ERR-RECORD-NOT-FOUND
+        ))
+    )
+        (asserts! (is-valid-string credential-uuid) ERR-INVALID-INPUT)
+        (asserts! (is-valid-principal student-address) ERR-ZERO-ADDRESS)
+        (asserts! (is-eq tx-sender (get education-provider-address credential-record)) ERR-NOT-AUTHORIZED)
+        (ok (map-set credential-records 
+            {credential-uuid: credential-uuid, student-address: student-address}
+            (merge credential-record {revocation-status: true})
+        ))
+    )
+)
+
+;; Read-only functions
+(define-read-only (get-credential-record
+    (credential-uuid (string-ascii 50))
+    (student-address principal)
+)
+    (map-get? credential-records 
+        {credential-uuid: credential-uuid, student-address: student-address}
+    )
+)
+
+(define-read-only (verify-credential-status
+    (credential-uuid (string-ascii 50))
+    (student-address principal)
+)
+    (match (map-get? credential-records 
+        {credential-uuid: credential-uuid, student-address: student-address}
+    )
+        credential-record (let (
+            (current-block-height stacks-block-height)
+            (credential-expired (> current-block-height (get expiration-block-height credential-record)))
+        )
+            (if (get revocation-status credential-record)
+                ERR-CREDENTIAL-STATUS-REVOKED
+                (if credential-expired
+                    ERR-CREDENTIAL-STATUS-EXPIRED
+                    (ok true)
+                )
+            ))
+        ERR-RECORD-NOT-FOUND
+    )
+)
+
+(define-read-only (get-education-provider-profile (provider-address principal))
+    (map-get? authorized-educational-institutions provider-address)
+)
+
+(define-read-only (get-credential-category-details (category-id (string-ascii 50)))
+    (map-get? supported-credential-categories category-id)
 )


### PR DESCRIPTION

## Pull Request Description

### Summary

This pull request extends the **STACKS-BlockCreds** smart contract by implementing the core functionality for managing individual educational credentials. It allows verified educational institutions to issue cryptographically hashed credentials to students, revoke credentials if necessary, and provides read-only queries to fetch credential records and verify their current status.

### Key Features

* **Issue Credential**
  Allows a verified education provider to issue a credential to a student by recording the credential UUID, type, document hash, and additional info. The credential’s validity period is calculated using the category’s configured validity in blocks. Duplicate credentials are prevented by UUID and student address.

* **Revoke Credential**
  Enables an education provider to revoke a previously issued credential, preventing it from being considered valid.

* **Credential Status Verification**
  Provides a method to check if a credential is currently valid, revoked, or expired based on blockchain block height and revocation status.

* **Data Retrieval Functions**
  Read-only functions to fetch detailed information about credentials, education providers, and credential categories.

### Validations and Error Handling

* Validates all string inputs to be non-empty.
* Validates student principal addresses to be non-zero and non-contract addresses.
* Validates the credential document hash buffer length and non-emptiness.
* Ensures only authorized and verified institutions can issue or revoke credentials.
* Returns specific error codes for various failure conditions such as duplicate credentials, unauthorized access, invalid inputs, and record not found.

### Data Structures

* `credential-records`: Stores credentials mapped by `{credential-uuid, student-address}`, including issuance info, expiration height, type, hash, additional info, and revocation status.
